### PR TITLE
Observe events generation

### DIFF
--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
@@ -9,6 +9,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
@@ -144,11 +145,12 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var rxMqttClinet = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
-
+            Func<MqttClientConnectedEventArgs, Task> d = null;
             testScheduler.Schedule(TimeSpan.FromTicks(2), () =>
-                mock.Mock<IManagedMqttClient>().Raise(x => x.ConnectedAsync += null, (object)EventArgs.Empty));
+                mock.Mock<IManagedMqttClient>().Raise(x => x.ConnectedAsync += null, (Func<MqttClientConnectedEventArgs, Task>)null));
             testScheduler.Schedule(TimeSpan.FromTicks(3), () =>
-                mock.Mock<IManagedMqttClient>().Raise(x => x.DisconnectedAsync += null, (object)EventArgs.Empty));
+                mock.Mock<IManagedMqttClient>().Raise(x => x.DisconnectedAsync += null, (Func<MqttClientDisconnectedEventArgs, Task>)null));
+           
             // act
             var testObserver = testScheduler.Start(() => rxMqttClinet.Connected, 0, 1, 4);
 

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
@@ -145,7 +145,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var rxMqttClinet = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
-            Func<MqttClientConnectedEventArgs, Task> d = null;
+
             testScheduler.Schedule(TimeSpan.FromTicks(2), () =>
                 mock.Mock<IManagedMqttClient>().Raise(x => x.ConnectedAsync += null, (Func<MqttClientConnectedEventArgs, Task>)null));
             testScheduler.Schedule(TimeSpan.FromTicks(3), () =>

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client/MQTTnet.Extensions.External.RxMQTT.Client.csproj
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client/MQTTnet.Extensions.External.RxMQTT.Client.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.0.247" />
+    <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.1.41">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client/MQTTnet.Extensions.External.RxMQTT.Client.csproj
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client/MQTTnet.Extensions.External.RxMQTT.Client.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.0.247" />
-    <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.1.41">
+    <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi, 
this PR refactors the generation of the async event observables to using the source generator of the nuget _ReactiveMarbles.ObservableEvents.SourceGenerator_ reducing your code to maintain.
cheers :wink: