### PR TITLE
Not setting IsHandled Flag

### DIFF
--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MultipleSimilarTopics.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MultipleSimilarTopics.cs
@@ -1,0 +1,51 @@
+﻿namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
+{
+	using Autofac.Extras.Moq;
+	using Microsoft.Reactive.Testing;
+	using MQTTnet.Client;
+	using MQTTnet.Extensions.ManagedClient;
+	using MQTTnet.Packets;
+	using System;
+	using System.Linq;
+	using System.Reactive.Concurrency;
+	using System.Reactive.Linq;
+	using Xunit;
+
+	public class MultipleSimilarTopics
+	{
+		[Fact]
+		public void ConnectMultipleSimilarTopics()
+		{
+			string connectTopic1 = "Test/MultiSimiliar/#";
+			string connectTopic2 = "Test/MultiSimiliar/+/subtopic/next";
+
+			string sendTopic = "Test/MultiSimiliar/bla/subtopic/next";
+
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
+
+			var rxMqttClient = mock.Create<RxMqttClient>();
+
+			var message1 = new MqttApplicationMessageBuilder()
+				.WithTopic(sendTopic)
+				.WithPayload("Hello World!")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
+
+			var testScheduler = new TestScheduler();
+
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
+
+			var result = testScheduler.Start(
+				() => rxMqttClient.Connect(connectTopic1)
+					.Select(message => (message, topic: 1))
+					.Merge(rxMqttClient.Connect(connectTopic2)
+						.Select(message => (message, topic: 2))),
+				0, 0, 10);
+
+			Assert.Single(result.Messages.Where(record => record.Value.Value.topic == 1));
+			Assert.Single(result.Messages.Where(record => record.Value.Value.topic == 2));
+		}
+	}
+}

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxPublischer.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxPublischer.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 {
-    public class RxPublischer
+    public class RxPublisher
     {
         [Fact]
         public void Publish_HasFailed()

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
@@ -250,7 +250,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_Subscribe_WithTwoSubscriptions_ReciveOnce()
+		public void Publish_Subscribe_WithTwoSubscriptions_ReciveOnce()
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
@@ -279,15 +279,19 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			// set up first subscription
 			var result = testScheduler
-				.Start(() => rxMqttClinet.Connect("T/A").Merge(rxMqttClinet.Connect("T/+")).DistinctUntilChanged(), 0, 0, 4);
+				.Start(() => rxMqttClinet.Connect("T/A").Merge(rxMqttClinet.Connect("T/+")), 0, 0, 4);
 
 			// test
-			Assert.Equal(2, result.Messages.Count);
-			Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
-			Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
-			Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
-			Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
-		}
+			Assert.Equal(4, result.Messages.Count);
+			Assert.Equal(NotificationKind.OnNext, result.Messages[0].Value.Kind);
+			Assert.Equal(NotificationKind.OnNext, result.Messages[1].Value.Kind);
+			Assert.Equal(NotificationKind.OnNext, result.Messages[2].Value.Kind);
+            Assert.Equal(NotificationKind.OnNext, result.Messages[3].Value.Kind);
+			Assert.Equal(eventArgs1, result.Messages[0].Value.Value);
+			Assert.Equal(eventArgs1, result.Messages[1].Value.Value);
+            Assert.Equal(eventArgs2, result.Messages[2].Value.Value);
+			Assert.Equal(eventArgs2, result.Messages[3].Value.Value);
+        }
 
 		[Fact]
 		public async void PublishAsync()

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
@@ -15,302 +15,302 @@ using Xunit;
 
 namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 {
-    public class RxSubscriber
-    {
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("")]
-        [InlineData(null)]
-        public void Connect_ArguemntException(string topic)
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
-            Assert.Throws<ArgumentException>(() => rxMqttClinet.Connect(topic));
-        }
+	public class RxSubscriber
+	{
+		[Theory]
+		[InlineData(" ")]
+		[InlineData("")]
+		[InlineData(null)]
+		public void Connect_ArguemntException(string topic)
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
+			Assert.Throws<ArgumentException>(() => rxMqttClinet.Connect(topic));
+		}
 
-        [Fact]
-        public void Connect_SubscribeAsync_Exception()
-        {
-            var exceptin = new Exception("Test");
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Throws(exceptin);
-            mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
+		[Fact]
+		public void Connect_SubscribeAsync_Exception()
+		{
+			var exceptin = new Exception("Test");
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Throws(exceptin);
+			mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
-            var testScheduler = new TestScheduler();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var testScheduler = new TestScheduler();
 
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 1);
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 1);
 
-            Assert.Single(result.Messages);
-            Assert.Single(result.Messages.Where(record => record.Value.Kind == NotificationKind.OnError));
-            Assert.Equal(exceptin, result.Messages.Where(record => record.Value.Kind == NotificationKind.OnError).Single().Value.Exception);
-            mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(It.IsAny<MqttNetLogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), exceptin), Times.Once);
-            mock.Mock<IManagedMqttClient>().Verify(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>()), Times.Once);
-        }
+			Assert.Single(result.Messages);
+			Assert.Single(result.Messages.Where(record => record.Value.Kind == NotificationKind.OnError));
+			Assert.Equal(exceptin, result.Messages.Where(record => record.Value.Kind == NotificationKind.OnError).Single().Value.Exception);
+			mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(It.IsAny<MqttNetLogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), exceptin), Times.Once);
+			mock.Mock<IManagedMqttClient>().Verify(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>()), Times.Once);
+		}
 
-        [Fact]
-        public void Disconnect_UnsubscribeAsync_Exception()
-        {
-            var exceptin = new Exception("Test");
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Returns(Task.CompletedTask);
-            mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(exceptin);
-            mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
+		[Fact]
+		public void Disconnect_UnsubscribeAsync_Exception()
+		{
+			var exceptin = new Exception("Test");
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Returns(Task.CompletedTask);
+			mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(exceptin);
+			mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
-            var testScheduler = new TestScheduler();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var testScheduler = new TestScheduler();
 
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
 
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
 
-            Assert.Empty(result.Messages);
-            mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(It.IsAny<MqttNetLogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), exceptin), Times.Once);
-            mock.Mock<IManagedMqttClient>().Verify(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>()), Times.Once);
-        }
+			Assert.Empty(result.Messages);
+			mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(It.IsAny<MqttNetLogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), exceptin), Times.Once);
+			mock.Mock<IManagedMqttClient>().Verify(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>()), Times.Once);
+		}
 
-        [Fact]
-        public void Disconnect_UnsubscribeAsync_ObjectDisposedException_Leads_To_No_Error()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Returns(Task.CompletedTask);
-            mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(new ObjectDisposedException(nameof(ManagedMqttClient)));
-            mock.Mock<IMqttNetLogger>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
-            var testScheduler = new TestScheduler();
+		[Fact]
+		public void Disconnect_UnsubscribeAsync_ObjectDisposedException_Leads_To_No_Error()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Returns(Task.CompletedTask);
+			mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(new ObjectDisposedException(nameof(ManagedMqttClient)));
+			mock.Mock<IMqttNetLogger>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var testScheduler = new TestScheduler();
 
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
 
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
 
-            Assert.Empty(result.Messages);
-            mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(MqttNetLogLevel.Error, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<Exception>()), Times.Never);
-        }
+			Assert.Empty(result.Messages);
+			mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(MqttNetLogLevel.Error, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<Exception>()), Times.Never);
+		}
 
-        [Fact]
-        public void Publisch_2Subscribe_2Recive_1Dispose_1Recive_Dispose()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
+		[Fact]
+		public void Publisch_2Subscribe_2Recive_1Dispose_1Recive_Dispose()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message1 = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P1")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
+			var message1 = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P1")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
 
-            var message2 = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P2")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
-            var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
+			var message2 = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P2")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
+			var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
 
-            var testScheduler = new TestScheduler();
+			var testScheduler = new TestScheduler();
 
-            // act
-            var firstCount = 0;
-            var first = rxMqttClinet.Connect("T").Subscribe(_ => firstCount++);
+			// act
+			var firstCount = 0;
+			var first = rxMqttClinet.Connect("T").Subscribe(_ => firstCount++);
 
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
-            testScheduler.Schedule(TimeSpan.FromTicks(3), () => first.Dispose());
-            testScheduler.Schedule(TimeSpan.FromTicks(4), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
+			testScheduler.Schedule(TimeSpan.FromTicks(3), () => first.Dispose());
+			testScheduler.Schedule(TimeSpan.FromTicks(4), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
 
-            var result = testScheduler.Start(() =>
-            {
-                IObservable<MqttApplicationMessageReceivedEventArgs> first = rxMqttClinet.Connect("T");
-                return rxMqttClinet.Connect("T");
-            }, 0, 0, 5);
+			var result = testScheduler.Start(() =>
+			{
+				IObservable<MqttApplicationMessageReceivedEventArgs> first = rxMqttClinet.Connect("T");
+				return rxMqttClinet.Connect("T");
+			}, 0, 0, 5);
 
-            // test
-            Assert.Equal(2, result.Messages.Count);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
-            Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
-            Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
-            Assert.Equal(1, firstCount);
-        }
+			// test
+			Assert.Equal(2, result.Messages.Count);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
+			Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
+			Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
+			Assert.Equal(1, firstCount);
+		}
 
-        [Fact]
-        public void Publisch_Subscribe_Once_And_2Recive_Dispose()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
+		[Fact]
+		public void Publisch_Subscribe_Once_And_2Recive_Dispose()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message1 = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P1")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
+			var message1 = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P1")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
 
-            var message2 = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P2")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
-            var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
+			var message2 = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P2")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
+			var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
 
-            var testScheduler = new TestScheduler();
+			var testScheduler = new TestScheduler();
 
-            // act
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
-            testScheduler.Schedule(TimeSpan.FromTicks(3), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
+			// act
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
+			testScheduler.Schedule(TimeSpan.FromTicks(3), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
 
-            // test
-            Assert.Equal(2, result.Messages.Count);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
-            Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
-            Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
-        }
+			// test
+			Assert.Equal(2, result.Messages.Count);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
+			Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
+			Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
+		}
 
-        [Fact]
-        public void Publisch_Subscribe_Once_And_Dispose_Client()
-        {
-            using var mock = AutoMock.GetLoose();
+		[Fact]
+		public void Publisch_Subscribe_Once_And_Dispose_Client()
+		{
+			using var mock = AutoMock.GetLoose();
 
-            mock.Mock<IManagedMqttClient>();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
-            var testScheduler = new TestScheduler();
+			var message = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
+			var testScheduler = new TestScheduler();
 
-            // act
-            testScheduler.Schedule(TimeSpan.FromTicks(3), () => rxMqttClinet.Dispose());
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
+			// act
+			testScheduler.Schedule(TimeSpan.FromTicks(3), () => rxMqttClinet.Dispose());
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
 
-            // test
-            Assert.Single(result.Messages);
-            Assert.Equal(NotificationKind.OnCompleted, result.Messages.Single().Value.Kind);
-        }
+			// test
+			Assert.Single(result.Messages);
+			Assert.Equal(NotificationKind.OnCompleted, result.Messages.Single().Value.Kind);
+		}
 
-        [Fact]
-        public void Publisch_Subscribe_Once_And_NotReciveDueFilter_Dispose()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
+		[Fact]
+		public void Publisch_Subscribe_Once_And_NotReciveDueFilter_Dispose()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic("N")
-                .WithPayload("P")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
-            var testScheduler = new TestScheduler();
+			var message = new MqttApplicationMessageBuilder()
+				.WithTopic("N")
+				.WithPayload("P")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
+			var testScheduler = new TestScheduler();
 
-            // act
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
+			// act
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
 
-            // test
-            Assert.Empty(result.Messages);
-        }
+			// test
+			Assert.Empty(result.Messages);
+		}
 
-        [Fact]
-        public void Publisch_Subscribe_Once_And_Recive_Dispose()
-        {
-            using var mock = AutoMock.GetLoose();
+		[Fact]
+		public void Publisch_Subscribe_Once_And_Recive_Dispose()
+		{
+			using var mock = AutoMock.GetLoose();
 
-            mock.Mock<IManagedMqttClient>();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
-            var testScheduler = new TestScheduler();
+			var message = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs = new MqttApplicationMessageReceivedEventArgs("1", message, mock.Create<MqttPublishPacket>(), null);
+			var testScheduler = new TestScheduler();
 
-            // act
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
-            var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
+			// act
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
+			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
 
-            // test
-            Assert.Single(result.Messages);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.Single().Value.Kind);
-            Assert.Equal(eventArgs, result.Messages.Single().Value.Value);
-        }
+			// test
+			Assert.Single(result.Messages);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.Single().Value.Kind);
+			Assert.Equal(eventArgs, result.Messages.Single().Value.Value);
+		}
 
-        [Fact]
-        public void Publisch_Subscribe_WithTwoSubscriptions_ReciveOnce()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
+		[Fact]
+		public void Publisch_Subscribe_WithTwoSubscriptions_ReciveOnce()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message1 = new MqttApplicationMessageBuilder()
-                .WithTopic("T/A")
-                .WithPayload("P1")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
+			var message1 = new MqttApplicationMessageBuilder()
+				.WithTopic("T/A")
+				.WithPayload("P1")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
 
-            var message2 = new MqttApplicationMessageBuilder()
-                .WithTopic("T/A")
-                .WithPayload("P2")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
-            var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
-            var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
+			var message2 = new MqttApplicationMessageBuilder()
+				.WithTopic("T/A")
+				.WithPayload("P2")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
+			var eventArgs1 = new MqttApplicationMessageReceivedEventArgs("1", message1, mock.Create<MqttPublishPacket>(), null);
+			var eventArgs2 = new MqttApplicationMessageReceivedEventArgs("1", message2, mock.Create<MqttPublishPacket>(), null);
 
-            var testScheduler = new TestScheduler();
+			var testScheduler = new TestScheduler();
 
-            // act
-            testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
-            testScheduler.Schedule(TimeSpan.FromTicks(3), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
+			// act
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
+			testScheduler.Schedule(TimeSpan.FromTicks(3), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
 
-            // set up first subscription
-            var result = testScheduler
-                .Start(() => rxMqttClinet.Connect("T/A").Merge(rxMqttClinet.Connect("T/+")), 0, 0, 4);
+			// set up first subscription
+			var result = testScheduler
+				.Start(() => rxMqttClinet.Connect("T/A").Merge(rxMqttClinet.Connect("T/+")).DistinctUntilChanged(), 0, 0, 4);
 
-            // test
-            Assert.Equal(2, result.Messages.Count);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
-            Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
-            Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
-            Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
-        }
+			// test
+			Assert.Equal(2, result.Messages.Count);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.First().Value.Kind);
+			Assert.Equal(NotificationKind.OnNext, result.Messages.Last().Value.Kind);
+			Assert.Equal(eventArgs1, result.Messages.First().Value.Value);
+			Assert.Equal(eventArgs2, result.Messages.Last().Value.Value);
+		}
 
-        [Fact]
-        public async void PublishAsync()
-        {
-            using var mock = AutoMock.GetLoose();
-            mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+		[Fact]
+		public async void PublishAsync()
+		{
+			using var mock = AutoMock.GetLoose();
+			mock.Mock<IManagedMqttClient>();
+			var rxMqttClinet = mock.Create<RxMqttClient>();
 
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic("T")
-                .WithPayload("P")
-                .WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
-                .Build();
+			var message = new MqttApplicationMessageBuilder()
+				.WithTopic("T")
+				.WithPayload("P")
+				.WithQualityOfServiceLevel(Protocol.MqttQualityOfServiceLevel.ExactlyOnce)
+				.Build();
 
-            var mangedMessage = new ManagedMqttApplicationMessageBuilder()
-                .WithApplicationMessage(message)
-                .Build();
+			var mangedMessage = new ManagedMqttApplicationMessageBuilder()
+				.WithApplicationMessage(message)
+				.Build();
 
-            // act
-            await rxMqttClinet.PublishAsync(mangedMessage);
+			// act
+			await rxMqttClinet.PublishAsync(mangedMessage);
 
-            // test
-            mock.Mock<IManagedMqttClient>().Verify(x => x.EnqueueAsync(mangedMessage));
-        }
-    }
+			// test
+			mock.Mock<IManagedMqttClient>().Verify(x => x.EnqueueAsync(mangedMessage));
+		}
+	}
 }

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
@@ -89,7 +89,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_2Subscribe_2Recive_1Dispose_1Recive_Dispose()
+		public void Publish_2Subscribe_2Recive_1Dispose_1Recive_Dispose()
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
@@ -136,7 +136,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_Subscribe_Once_And_2Recive_Dispose()
+		public void Publish_Subscribe_Once_And_2Recive_Dispose()
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
@@ -173,7 +173,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_Subscribe_Once_And_Dispose_Client()
+		public void Publish_Subscribe_Once_And_Dispose_Client()
 		{
 			using var mock = AutoMock.GetLoose();
 
@@ -199,7 +199,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_Subscribe_Once_And_NotReciveDueFilter_Dispose()
+		public void Publish_Subscribe_Once_And_NotReciveDueFilter_Dispose()
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
@@ -223,7 +223,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		}
 
 		[Fact]
-		public void Publisch_Subscribe_Once_And_Recive_Dispose()
+		public void Publish_Subscribe_Once_And_Recive_Dispose()
 		{
 			using var mock = AutoMock.GetLoose();
 

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client/RxMqttClient.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client/RxMqttClient.cs
@@ -14,246 +14,233 @@ using System.Threading.Tasks;
 
 namespace MQTTnet.Extensions.External.RxMQTT.Client
 {
-    /// <summary>
-    /// A mqtt client using <see cref="System.Reactive" /> for subscribing to topics.
-    /// </summary>
-    public class RxMqttClient : Internal.Disposable, IRxMqttClient
-    {
-        private readonly IObservable<MqttApplicationMessageReceivedEventArgs> applicationMessageReceived;
+	/// <summary>
+	/// A mqtt client using <see cref="System.Reactive" /> for subscribing to topics.
+	/// </summary>
+	public class RxMqttClient : Internal.Disposable, IRxMqttClient
+	{
+		private readonly IObservable<MqttApplicationMessageReceivedEventArgs> applicationMessageReceived;
 
-        private readonly IDisposable cleanUp;
-        private readonly MqttNetSourceLogger logger;
-        private readonly object setHandledLock = new object();
-        private readonly Dictionary<string, IObservable<MqttApplicationMessageReceivedEventArgs>> topicSubscriptionCache;
-        private readonly object topicSubscriptionLock = new object();
+		private readonly IDisposable cleanUp;
+		private readonly MqttNetSourceLogger logger;
+		private readonly object setHandledLock = new object();
+		private readonly Dictionary<string, IObservable<MqttApplicationMessageReceivedEventArgs>> topicSubscriptionCache;
+		private readonly object topicSubscriptionLock = new object();
 
-        /// <summary>
-        /// Create a rx mqtt client based on a <see cref="ManagedMqttClient" />.
-        /// </summary>
-        /// <param name="managedMqttClient">The manged mqtt client.</param>
-        /// <param name="logger">The mqtt net logger.</param>
-        /// <remarks>
-        /// Use the
-        /// <see cref="MqttFactoryExtensions.CreateRxMqttClient(MqttFactory)" />
-        /// or
-        /// <see cref="MqttFactoryExtensions.CreateRxMqttClient(MqttFactory, IMqttNetLogger)" />
-        /// factory methods to crate the client.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException"></exception>
-        public RxMqttClient(IManagedMqttClient managedMqttClient, IMqttNetLogger logger)
-        {
-            InternalClient = managedMqttClient ?? throw new ArgumentNullException(nameof(managedMqttClient));
-            if (logger == null) throw new ArgumentNullException(nameof(logger));
+		/// <summary>
+		/// Create a rx mqtt client based on a <see cref="ManagedMqttClient" />.
+		/// </summary>
+		/// <param name="managedMqttClient">The manged mqtt client.</param>
+		/// <param name="logger">The mqtt net logger.</param>
+		/// <remarks>
+		/// Use the
+		/// <see cref="MqttFactoryExtensions.CreateRxMqttClient(MqttFactory)" />
+		/// or
+		/// <see cref="MqttFactoryExtensions.CreateRxMqttClient(MqttFactory, IMqttNetLogger)" />
+		/// factory methods to crate the client.
+		/// </remarks>
+		/// <exception cref="ArgumentNullException"></exception>
+		public RxMqttClient(IManagedMqttClient managedMqttClient, IMqttNetLogger logger)
+		{
+			InternalClient = managedMqttClient ?? throw new ArgumentNullException(nameof(managedMqttClient));
+			if (logger == null) throw new ArgumentNullException(nameof(logger));
 
-            this.logger = logger.WithSource(nameof(RxMqttClient));
-            topicSubscriptionCache = new Dictionary<string, IObservable<MqttApplicationMessageReceivedEventArgs>>();
+			this.logger = logger.WithSource(nameof(RxMqttClient));
+			topicSubscriptionCache = new Dictionary<string, IObservable<MqttApplicationMessageReceivedEventArgs>>();
 
-            var cancelationSubject = new Subject<Unit>();
+			var cancelationSubject = new Subject<Unit>();
 
-            var managedMqttClientEvents = managedMqttClient.Events();
+			var managedMqttClientEvents = managedMqttClient.Events();
 
-            ConnectedEvent = managedMqttClientEvents.ConnectedAsync
-                .TakeUntil(cancelationSubject);
+			ConnectedEvent = managedMqttClientEvents.ConnectedAsync
+				.TakeUntil(cancelationSubject);
 
-            DisconnectedEvent = managedMqttClientEvents.DisconnectedAsync
-                .TakeUntil(cancelationSubject);
+			DisconnectedEvent = managedMqttClientEvents.DisconnectedAsync
+				.TakeUntil(cancelationSubject);
 
-            ConnectingFailedEvent = managedMqttClientEvents.ConnectingFailedAsync
-                .TakeUntil(cancelationSubject);
+			ConnectingFailedEvent = managedMqttClientEvents.ConnectingFailedAsync
+				.TakeUntil(cancelationSubject);
 
-            SynchronizingSubscriptionsFailedEvent = managedMqttClientEvents.SynchronizingSubscriptionsFailedAsync
-                .TakeUntil(cancelationSubject);
+			SynchronizingSubscriptionsFailedEvent = managedMqttClientEvents.SynchronizingSubscriptionsFailedAsync
+				.TakeUntil(cancelationSubject);
 
-            ApplicationMessageProcessedEvent = managedMqttClientEvents.ApplicationMessageProcessedAsync
-                .TakeUntil(cancelationSubject);
+			ApplicationMessageProcessedEvent = managedMqttClientEvents.ApplicationMessageProcessedAsync
+				.TakeUntil(cancelationSubject);
 
-            ApplicationMessageSkippedEvent = managedMqttClientEvents.ApplicationMessageSkippedAsync
-                .TakeUntil(cancelationSubject);
+			ApplicationMessageSkippedEvent = managedMqttClientEvents.ApplicationMessageSkippedAsync
+				.TakeUntil(cancelationSubject);
 
-            Connected = Observable
-                .Create<bool>(observer =>
-                {
-                    var connected = ConnectedEvent.Subscribe(_ => observer.OnNext(true));
-                    var disconnected = DisconnectedEvent.Subscribe(_ => observer.OnNext(false));
-                    return new CompositeDisposable(connected, disconnected);
-                })
-                .TakeUntil(cancelationSubject)      // complete on dispose
-                .Prepend(IsConnected)               // start with current state
-                .Append(false)                      // finish with false
-                .Replay(1)                          // replay last state on subscribe
-                .RefCount();                        // count subscriptions and dispose source observable when no subscription
+			Connected = Observable
+				.Create<bool>(observer =>
+				{
+					var connected = ConnectedEvent.Subscribe(_ => observer.OnNext(true));
+					var disconnected = DisconnectedEvent.Subscribe(_ => observer.OnNext(false));
+					return new CompositeDisposable(connected, disconnected);
+				})
+				.TakeUntil(cancelationSubject)      // complete on dispose
+				.Prepend(IsConnected)               // start with current state
+				.Append(false)                      // finish with false
+				.Replay(1)                          // replay last state on subscribe
+				.RefCount();                        // count subscriptions and dispose source observable when no subscription
 
-            applicationMessageReceived = managedMqttClientEvents.ApplicationMessageReceivedAsync
-                .TakeUntil(cancelationSubject);
+			applicationMessageReceived = managedMqttClientEvents.ApplicationMessageReceivedAsync
+				.TakeUntil(cancelationSubject);
 
-            cleanUp = Disposable.Create(() =>
-            {
-                cancelationSubject.OnNext(Unit.Default);    // complete all observers
-                cancelationSubject.Dispose();
-                try { managedMqttClient.Dispose(); }
-                catch { }
-            });
-        }
+			cleanUp = Disposable.Create(() =>
+			{
+				cancelationSubject.OnNext(Unit.Default);    // complete all observers
+				cancelationSubject.Dispose();
+				try { managedMqttClient.Dispose(); }
+				catch { }
+			});
+		}
 
-        /// <inheritdoc />
-        public IObservable<ApplicationMessageProcessedEventArgs> ApplicationMessageProcessedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<ApplicationMessageProcessedEventArgs> ApplicationMessageProcessedEvent { get; }
 
-        /// <inheritdoc />
-        public IObservable<ApplicationMessageSkippedEventArgs> ApplicationMessageSkippedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<ApplicationMessageSkippedEventArgs> ApplicationMessageSkippedEvent { get; }
 
-        /// <inheritdoc />
-        public IObservable<bool> Connected { get; }
+		/// <inheritdoc />
+		public IObservable<bool> Connected { get; }
 
-        /// <inheritdoc />
-        public IObservable<EventArgs> ConnectedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<EventArgs> ConnectedEvent { get; }
 
-        /// <inheritdoc />
-        public IObservable<ConnectingFailedEventArgs> ConnectingFailedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<ConnectingFailedEventArgs> ConnectingFailedEvent { get; }
 
-        /// <inheritdoc />
-        public IObservable<EventArgs> DisconnectedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<EventArgs> DisconnectedEvent { get; }
 
-        /// <inheritdoc />
-        public IManagedMqttClient InternalClient { get; }
+		/// <inheritdoc />
+		public IManagedMqttClient InternalClient { get; }
 
-        /// <inheritdoc />
-        public bool IsConnected => InternalClient.IsConnected;
+		/// <inheritdoc />
+		public bool IsConnected => InternalClient.IsConnected;
 
-        /// <inheritdoc />
-        public bool IsStarted => InternalClient.IsStarted;
+		/// <inheritdoc />
+		public bool IsStarted => InternalClient.IsStarted;
 
-        /// <inheritdoc />
-        public ManagedMqttClientOptions Options => InternalClient.Options;
+		/// <inheritdoc />
+		public ManagedMqttClientOptions Options => InternalClient.Options;
 
-        /// <inheritdoc />
-        public int PendingApplicationMessagesCount => InternalClient.PendingApplicationMessagesCount;
+		/// <inheritdoc />
+		public int PendingApplicationMessagesCount => InternalClient.PendingApplicationMessagesCount;
 
-        /// <inheritdoc />
-        public IObservable<ManagedProcessFailedEventArgs> SynchronizingSubscriptionsFailedEvent { get; }
+		/// <inheritdoc />
+		public IObservable<ManagedProcessFailedEventArgs> SynchronizingSubscriptionsFailedEvent { get; }
 
-        /// <inheritdoc />
-        /// <exception cref="ArgumentException"></exception>
-        public IObservable<MqttApplicationMessageReceivedEventArgs> Connect(string topic)
-        {
-            if (string.IsNullOrWhiteSpace(topic))
-                throw new ArgumentException($"'{nameof(topic)}' cannot be null or whitespace", nameof(topic));
+		/// <inheritdoc />
+		/// <exception cref="ArgumentException"></exception>
+		public IObservable<MqttApplicationMessageReceivedEventArgs> Connect(string topic)
+		{
+			if (string.IsNullOrWhiteSpace(topic))
+				throw new ArgumentException($"'{nameof(topic)}' cannot be null or whitespace", nameof(topic));
 
-            ThrowIfDisposed();
-            lock (topicSubscriptionLock)
-            {
-                // try get exiting observable for topic
-                if (!topicSubscriptionCache.TryGetValue(topic, out IObservable<MqttApplicationMessageReceivedEventArgs> observable))
-                {
-                    // create new observable for topic
-                    observable = Observable
-                        .Create<MqttApplicationMessageReceivedEventArgs>(async observer =>
-                        {
-                            // subscribe to topic
-                            try
-                            {
-                                var mqttTopicFilter = new MqttTopicFilterBuilder()
-                                    .WithTopic(topic)
-                                    .Build();
-                                await InternalClient.SubscribeAsync(new[] { mqttTopicFilter }).ConfigureAwait(false);
-                            }
-                            catch (Exception exception)
-                            {
-                                logger.Error(exception, "Error while maintaining subscribe from topic.");
-                                observer.OnError(exception);
-                                return Disposable.Empty;
-                            }
+			ThrowIfDisposed();
+			lock (topicSubscriptionLock)
+			{
+				// try get exiting observable for topic
+				if (!topicSubscriptionCache.TryGetValue(topic, out IObservable<MqttApplicationMessageReceivedEventArgs> observable))
+				{
+					// create new observable for topic
+					observable = Observable
+						.Create<MqttApplicationMessageReceivedEventArgs>(async observer =>
+						{
+							// subscribe to topic
+							try
+							{
+								var mqttTopicFilter = new MqttTopicFilterBuilder()
+									.WithTopic(topic)
+									.Build();
+								await InternalClient.SubscribeAsync(new[] { mqttTopicFilter }).ConfigureAwait(false);
+							}
+							catch (Exception exception)
+							{
+								logger.Error(exception, "Error while maintaining subscribe from topic.");
+								observer.OnError(exception);
+								return Disposable.Empty;
+							}
 
-                            // filter all received messages and subscribe to
-                            // messages for this topic
-                            var messageSubscription = applicationMessageReceived
-                                .FilterTopic(topic)
-                                .Where(message =>
-                                {
-                                    // set handled after first filter match
-                                    // to avoid getting messages for subscriptions to e.g.
-                                    //  - A/*
-                                    //  - A/B
-                                    lock (setHandledLock)
-                                    {
-                                        var isHandled = message.IsHandled;
-                                        message.IsHandled = true;
-                                        return !isHandled;
-                                    }
-                                })
-                                .Subscribe(observer);
+							// filter all received messages and subscribe to
+							// messages for this topic
+							var messageSubscription = applicationMessageReceived
+								.FilterTopic(topic)
+								.Subscribe(observer);
 
-                            return Disposable.Create(async () =>
-                                {
-                                    // clean up subscription when no observer subscribed
-                                    lock (topicSubscriptionLock)
-                                    {
-                                        messageSubscription.Dispose();
-                                        topicSubscriptionCache.Remove(topic);
-                                    }
-                                    try
-                                    {
-                                        await InternalClient.UnsubscribeAsync(new[] { topic }).ConfigureAwait(false);
-                                    }
-                                    catch (ObjectDisposedException) { } // if disposed there is nothing to unsubscribe
-                                    catch (Exception exception)
-                                    {
-                                        logger.Error(exception, "Error while maintaining unsubscribe from topic.");
-                                    }
-                                });
-                        })
-                        .Publish()      // publish from on source observable
-                        .RefCount();    // count subscriptions and dispose source observable when no subscription
+							return Disposable.Create(async () =>
+								{
+									// clean up subscription when no observer subscribed
+									lock (topicSubscriptionLock)
+									{
+										messageSubscription.Dispose();
+										topicSubscriptionCache.Remove(topic);
+									}
+									try
+									{
+										await InternalClient.UnsubscribeAsync(new[] { topic }).ConfigureAwait(false);
+									}
+									catch (ObjectDisposedException) { } // if disposed there is nothing to unsubscribe
+									catch (Exception exception)
+									{
+										logger.Error(exception, "Error while maintaining unsubscribe from topic.");
+									}
+								});
+						})
+						.Publish()      // publish from on source observable
+						.RefCount();    // count subscriptions and dispose source observable when no subscription
 
-                    topicSubscriptionCache.Add(topic, observable);
-                }
-                return observable;
-            }
-        }
+					topicSubscriptionCache.Add(topic, observable);
+				}
+				return observable;
+			}
+		}
 
-        /// <inheritdoc />
-        public Task PingAsync(CancellationToken cancellationToken)
-        {
-            return InternalClient.PingAsync(cancellationToken);
-        }
+		/// <inheritdoc />
+		public Task PingAsync(CancellationToken cancellationToken)
+		{
+			return InternalClient.PingAsync(cancellationToken);
+		}
 
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"></exception>
-        public Task PublishAsync(ManagedMqttApplicationMessage applicationMessage)
-        {
-            if (applicationMessage is null) throw new ArgumentNullException(nameof(applicationMessage));
+		/// <inheritdoc />
+		/// <exception cref="ArgumentNullException"></exception>
+		public Task PublishAsync(ManagedMqttApplicationMessage applicationMessage)
+		{
+			if (applicationMessage is null) throw new ArgumentNullException(nameof(applicationMessage));
 
-            return InternalClient.EnqueueAsync(applicationMessage);
-        }
+			return InternalClient.EnqueueAsync(applicationMessage);
+		}
 
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"></exception>
-        public Task PublishAsync(MqttApplicationMessage applicationMessage)
-        {
-            if (applicationMessage is null) throw new ArgumentNullException(nameof(applicationMessage));
+		/// <inheritdoc />
+		/// <exception cref="ArgumentNullException"></exception>
+		public Task PublishAsync(MqttApplicationMessage applicationMessage)
+		{
+			if (applicationMessage is null) throw new ArgumentNullException(nameof(applicationMessage));
 
-            return InternalClient.EnqueueAsync(applicationMessage);
-        }
+			return InternalClient.EnqueueAsync(applicationMessage);
+		}
 
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"></exception>
-        public Task StartAsync(ManagedMqttClientOptions options)
-        {
-            if (options is null) throw new ArgumentNullException(nameof(options));
+		/// <inheritdoc />
+		/// <exception cref="ArgumentNullException"></exception>
+		public Task StartAsync(ManagedMqttClientOptions options)
+		{
+			if (options is null) throw new ArgumentNullException(nameof(options));
 
-            return InternalClient.StartAsync(options);
-        }
+			return InternalClient.StartAsync(options);
+		}
 
-        /// <inheritdoc />
-        public Task StopAsync()
-        {
-            return InternalClient.StopAsync();
-        }
+		/// <inheritdoc />
+		public Task StopAsync()
+		{
+			return InternalClient.StopAsync();
+		}
 
-        /// <inheritdoc />
-        protected override void Dispose(bool disposing)
-        {
-            cleanUp.Dispose();
-            base.Dispose(disposing);
-        }
-    }
+		/// <inheritdoc />
+		protected override void Dispose(bool disposing)
+		{
+			cleanUp.Dispose();
+			base.Dispose(disposing);
+		}
+	}
 }


### PR DESCRIPTION
Hi,

sorry for the "big" changes, its actually not that much.

I noticed that on multiple connects to similar topics (like A/# and A/*/C) only the first result observable (connected to A/#) will get the message. I tracked it down to these lines: 
https://github.com/mmuecke/RxMQTTnet/compare/main...nilsauf:connectSimilarTopics?expand=1#diff-07d9a2b4540c1cda6d74982321e8bd0c910899c2d094e41751c6a20ccd801936L170-L182 
By setting the "IsHandled" Flag, no other stream will receive the message.

This PR fixes this and adds a test case for it. 
It also adds a DistinctUntilChanged to the "Publisch_Subscribe_WithTwoSubscriptions_ReciveOnce" Test.

cheers