### PR TITLE
Fix typos in variable names in test files

### DIFF
--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/MangedClientWrapperTest.cs
@@ -22,7 +22,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         public void ApplicationMessageProcessedHandler()
         {
             using var mock = AutoMock.GetLoose();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
@@ -32,7 +32,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 mock.Mock<IManagedMqttClient>().Raise(m => m.ApplicationMessageProcessedAsync -= null, (object)@event));
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.ApplicationMessageProcessedEvent, 0, 0, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.ApplicationMessageProcessedEvent, 0, 0, 4);
 
             Assert.Equal(1, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);
@@ -46,13 +46,13 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var message = new ManagedMqttApplicationMessage();
             var @event = new ApplicationMessageSkippedEventArgs(message); ;
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
             testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(m => m.ApplicationMessageSkippedAsync += null, (object)@event));
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.ApplicationMessageSkippedEvent, 0, 0, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.ApplicationMessageSkippedEvent, 0, 0, 4);
 
             Assert.Equal(1, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);
@@ -64,14 +64,14 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
             testScheduler.Schedule(TimeSpan.FromTicks(3), () =>
                 mock.Mock<IManagedMqttClient>().Raise(x => x.ConnectedAsync += null, (object)new MqttClientConnectedEventArgs(new MqttClientConnectResult())));
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.Connected, 0, 0, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.Connected, 0, 0, 4);
 
             Assert.Equal(2, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);
@@ -85,12 +85,12 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             using var mock = AutoMock.GetLoose();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.Connected, 0, 0, 1);
+            var testObserver = testScheduler.Start(() => rxMqttClient.Connected, 0, 0, 1);
 
             Assert.Single(testObserver.Messages);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Single().Value.Kind);
@@ -102,7 +102,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
@@ -111,7 +111,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Raise(x => x.ConnectingFailedAsync -= null, (object)@event));
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.ConnectingFailedEvent, 0, 0, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.ConnectingFailedEvent, 0, 0, 4);
 
             Assert.Equal(1, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);
@@ -144,7 +144,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
@@ -154,7 +154,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 mock.Mock<IManagedMqttClient>().Raise(x => x.DisconnectedAsync += null, (Func<MqttClientDisconnectedEventArgs, Task>)null));
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.Connected, 0, 1, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.Connected, 0, 1, 4);
 
             Assert.Equal(3, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);
@@ -171,10 +171,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Throws(new Exception());
 
             // act
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // test
-            rxMqttClinet.Dispose();
+            rxMqttClient.Dispose();
         }
 
         [Fact]
@@ -198,17 +198,17 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         [Fact]
         public void Factory_NullException_With_Logger()
         {
-            var looger = new MqttNetEventLogger("MyCustomId");
+            var logger = new MqttNetEventLogger("MyCustomId");
             // act
-            Assert.Throws<ArgumentNullException>(() => ((MqttFactory)null).CreateRxMqttClient(looger));
+            Assert.Throws<ArgumentNullException>(() => ((MqttFactory)null).CreateRxMqttClient(logger));
         }
 
         [Fact]
         public void Factory_With_Logger()
         {
-            var looger = new MqttNetEventLogger("MyCustomId");
+            var logger = new MqttNetEventLogger("MyCustomId");
             // act
-            var client = new MqttFactory().CreateRxMqttClient(looger);
+            var client = new MqttFactory().CreateRxMqttClient(logger);
 
             // test
             Assert.NotNull(client);
@@ -239,14 +239,14 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             mock.Mock<IManagedMqttClient>()
                 .Setup(x => x.Options)
                 .Returns(options);
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            await rxMqttClinet.StartAsync(options);
+            await rxMqttClient.StartAsync(options);
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.StartAsync(options));
-            Assert.Equal(options, rxMqttClinet.Options);
+            Assert.Equal(options, rxMqttClient.Options);
         }
 
         [Fact]
@@ -260,10 +260,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Returns(count);
 
             // act
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // test
-            Assert.Equal(count, rxMqttClinet.PendingApplicationMessagesCount);
+            Assert.Equal(count, rxMqttClient.PendingApplicationMessagesCount);
         }
 
         [Fact]
@@ -272,12 +272,12 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             using var mock = AutoMock.GetLoose();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var cts = new CancellationToken();
 
             // act
-            await rxMqttClinet.PingAsync(cts);
+            await rxMqttClient.PingAsync(cts);
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.PingAsync(cts));
@@ -290,10 +290,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var message = new ManagedMqttApplicationMessage();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            await rxMqttClinet.PublishAsync(message);
+            await rxMqttClient.PublishAsync(message);
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.EnqueueAsync(message));
@@ -304,13 +304,13 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            RxMqttClient rxMqttClinet = mock.Create<RxMqttClient>();
+            RxMqttClient rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
             _ = Assert.ThrowsAsync<ArgumentNullException>(() =>
-                rxMqttClinet.PublishAsync((ManagedMqttApplicationMessage)null));
+                rxMqttClient.PublishAsync((ManagedMqttApplicationMessage)null));
             _ = Assert.ThrowsAsync<ArgumentNullException>(() =>
-                rxMqttClinet.PublishAsync((MqttApplicationMessage)null));
+                rxMqttClient.PublishAsync((MqttApplicationMessage)null));
         }
 
         [Fact]
@@ -320,10 +320,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var message = new MqttApplicationMessage();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            await rxMqttClinet.PublishAsync(message);
+            await rxMqttClient.PublishAsync(message);
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.EnqueueAsync(message));
@@ -334,11 +334,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
             _ = Assert.ThrowsAsync<ArgumentNullException>(() =>
-                rxMqttClinet.PublishAsync((ManagedMqttApplicationMessage)null));
+                rxMqttClient.PublishAsync((ManagedMqttApplicationMessage)null));
         }
 
         [Theory]
@@ -353,10 +353,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Returns(isStarted);
 
             // act
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // test
-            Assert.Equal(isStarted, rxMqttClinet.IsConnected);
+            Assert.Equal(isStarted, rxMqttClient.IsConnected);
         }
 
         [Theory]
@@ -371,10 +371,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Returns(isStarted);
 
             // act
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // test
-            Assert.Equal(isStarted, rxMqttClinet.IsStarted);
+            Assert.Equal(isStarted, rxMqttClient.IsStarted);
         }
 
         [Fact]
@@ -391,10 +391,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .Build();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            await rxMqttClinet.StartAsync(options);
+            await rxMqttClient.StartAsync(options);
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.StartAsync(options));
@@ -405,10 +405,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            _ = Assert.ThrowsAsync<ArgumentNullException>(() => rxMqttClinet.StartAsync(null));
+            _ = Assert.ThrowsAsync<ArgumentNullException>(() => rxMqttClient.StartAsync(null));
         }
 
         [Fact]
@@ -417,10 +417,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             using var mock = AutoMock.GetLoose();
 
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             // act
-            await rxMqttClinet.StopAsync();
+            await rxMqttClient.StopAsync();
 
             // test
             mock.Mock<IManagedMqttClient>().Verify(x => x.StopAsync(true));
@@ -430,7 +430,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         public void SynchronizingSubscriptionsFailedHandler()
         {
             using var mock = AutoMock.GetLoose();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var testScheduler = new TestScheduler();
 
@@ -443,7 +443,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 mock.Mock<IManagedMqttClient>().Raise(x => x.SynchronizingSubscriptionsFailedAsync += null, (object)@event));
 
             // act
-            var testObserver = testScheduler.Start(() => rxMqttClinet.SynchronizingSubscriptionsFailedEvent, 0, 0, 4);
+            var testObserver = testScheduler.Start(() => rxMqttClient.SynchronizingSubscriptionsFailedEvent, 0, 0, 4);
 
             Assert.Equal(1, testObserver.Messages.Count);
             Assert.Equal(NotificationKind.OnNext, testObserver.Messages.Last().Value.Kind);

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxPublischer.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxPublischer.cs
@@ -25,7 +25,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .SetupGet(x => x.IsConnected)
                 .Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -43,7 +43,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageProcessedAsync -= null, (object)@event));
 
             // act
-            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClinet), 0, 1, 10);
+            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClient), 0, 1, 10);
 
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnNext));
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnCompleted));
@@ -65,7 +65,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .SetupGet(x => x.IsConnected)
                 .Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -82,7 +82,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                  mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageSkippedAsync -= null, (object)@event));
             
             // act
-            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClinet), 0, 1, 10);
+            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClient), 0, 1, 10);
 
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnNext));
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnCompleted));
@@ -104,7 +104,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .SetupGet(x => x.IsConnected)
                 .Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -120,7 +120,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             testScheduler.Schedule(TimeSpan.FromTicks(5), () =>
                 mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageProcessedAsync -= null, (object )@event));
             // act
-            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClinet), 0, 1, 10);
+            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClient), 0, 1, 10);
 
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnNext));
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnCompleted));
@@ -143,7 +143,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
                 .SetupGet(x => x.IsConnected)
                 .Returns(true);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -159,7 +159,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             testScheduler.Schedule(TimeSpan.FromTicks(5), () =>
                 mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageProcessedAsync -= null, (object)@event));
             // act
-            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClinet), 0, 1, 10);
+            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClient), 0, 1, 10);
 
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnNext));
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnCompleted));
@@ -178,7 +178,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageProcessedEvent).Returns(Observable.Never<ApplicationMessageProcessedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageSkippedEvent).Returns(Observable.Never<ApplicationMessageSkippedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.IsConnected).Returns(true);
-            var rxMqttClinet = mock.Mock<IRxMqttClient>();
+            var rxMqttClient = mock.Mock<IRxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -190,10 +190,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var observable = Observable.Return(message);
 
             // act
-            rxMqttClinet.Object.Publish(observable).Subscribe();
+            rxMqttClient.Object.Publish(observable).Subscribe();
 
             // test
-            rxMqttClinet.Verify(x => x.PublishAsync(message));
+            rxMqttClient.Verify(x => x.PublishAsync(message));
         }
 
         [Fact]
@@ -201,11 +201,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
             IObservable<ManagedMqttApplicationMessage> observable = null;
 
             // test
-            Assert.Throws<ArgumentNullException>(() => rxMqttClinet.Publish(observable));
+            Assert.Throws<ArgumentNullException>(() => rxMqttClient.Publish(observable));
         }
 
         [Fact]
@@ -213,11 +213,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            RxMqttClient rxMqttClinet = null;
+            RxMqttClient rxMqttClient = null;
             var observable = Observable.Never<ManagedMqttApplicationMessage>();
 
             // test
-            Assert.Throws<ArgumentNullException>(() => rxMqttClinet.Publish(observable));
+            Assert.Throws<ArgumentNullException>(() => rxMqttClient.Publish(observable));
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageProcessedEvent).Returns(Observable.Never<ApplicationMessageProcessedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageSkippedEvent).Returns(Observable.Never<ApplicationMessageSkippedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.IsConnected).Returns(true);
-            var rxMqttClinet = mock.Mock<IRxMqttClient>();
+            var rxMqttClient = mock.Mock<IRxMqttClient>();
 
             var message = new MqttApplicationMessageBuilder()
                 .WithTopic("T")
@@ -239,10 +239,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var observable = Observable.Return(message);
 
             // act
-            rxMqttClinet.Object.Publish(observable).Subscribe();
+            rxMqttClient.Object.Publish(observable).Subscribe();
 
             // test
-            rxMqttClinet.Verify(x => x.PublishAsync(It.IsAny<ManagedMqttApplicationMessage>()));
+            rxMqttClient.Verify(x => x.PublishAsync(It.IsAny<ManagedMqttApplicationMessage>()));
         }
 
         [Fact]
@@ -250,11 +250,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
             IObservable<MqttApplicationMessage> observable = null;
 
             // test
-            Assert.Throws<ArgumentNullException>(() => rxMqttClinet.Publish(observable));
+            Assert.Throws<ArgumentNullException>(() => rxMqttClient.Publish(observable));
         }
 
         [Fact]
@@ -262,11 +262,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            RxMqttClient rxMqttClinet = null;
+            RxMqttClient rxMqttClient = null;
             var observable = Observable.Never<MqttApplicationMessage>();
 
             // test
-            Assert.Throws<ArgumentNullException>(() => rxMqttClinet.Publish(observable));
+            Assert.Throws<ArgumentNullException>(() => rxMqttClient.Publish(observable));
         }
 
         [Fact]
@@ -277,7 +277,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             mock.Mock<IManagedMqttClient>()
                 .Setup(x => x.EnqueueAsync(It.IsAny<ManagedMqttApplicationMessage>())).Returns(Task.CompletedTask);
 
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
 
             var message = new ManagedMqttApplicationMessageBuilder()
                 .WithApplicationMessage(new MqttApplicationMessageBuilder()
@@ -291,7 +291,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
             var testScheduler = new TestScheduler();
             // act
-            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClinet), 0, 0, 2);
+            var testObserver = testScheduler.Start(() => observable.PublishOn(rxMqttClient), 0, 0, 2);
 
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnNext));
             Assert.Single(testObserver.Messages.Where(m => m.Value.Kind == System.Reactive.NotificationKind.OnCompleted));
@@ -307,11 +307,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
             IObservable<ManagedMqttApplicationMessage> observable = null;
 
             // test
-            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClinet));
+            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClient));
         }
 
         [Fact]
@@ -319,11 +319,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            RxMqttClient rxMqttClinet = null;
+            RxMqttClient rxMqttClient = null;
             var observable = Observable.Never<ManagedMqttApplicationMessage>();
 
             // test
-            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClinet));
+            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClient));
         }
 
         [Fact]
@@ -334,7 +334,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageProcessedEvent).Returns(Observable.Never<ApplicationMessageProcessedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.ApplicationMessageSkippedEvent).Returns(Observable.Never<ApplicationMessageSkippedEventArgs>());
             mock.Mock<IRxMqttClient>().Setup(x => x.IsConnected).Returns(true);
-            var rxMqttClinet = mock.Mock<IRxMqttClient>();
+            var rxMqttClient = mock.Mock<IRxMqttClient>();
 
             var message = new MqttApplicationMessageBuilder()
                 .WithTopic("T")
@@ -345,10 +345,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
             var observable = Observable.Return(message);
 
             // act
-            observable.PublishOn(rxMqttClinet.Object).Subscribe();
+            observable.PublishOn(rxMqttClient.Object).Subscribe();
 
             // test
-            rxMqttClinet.Verify(x => x.PublishAsync(It.IsAny<ManagedMqttApplicationMessage>()));
+            rxMqttClient.Verify(x => x.PublishAsync(It.IsAny<ManagedMqttApplicationMessage>()));
         }
 
         [Fact]
@@ -356,11 +356,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            var rxMqttClinet = mock.Create<RxMqttClient>();
+            var rxMqttClient = mock.Create<RxMqttClient>();
             IObservable<MqttApplicationMessage> observable = null;
 
             // test
-            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClinet));
+            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClient));
         }
 
         [Fact]
@@ -368,11 +368,11 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
         {
             using var mock = AutoMock.GetLoose();
             mock.Mock<IManagedMqttClient>();
-            RxMqttClient rxMqttClinet = null;
+            RxMqttClient rxMqttClient = null;
             var observable = Observable.Never<MqttApplicationMessage>();
 
             // test
-            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClinet));
+            Assert.Throws<ArgumentNullException>(() => observable.PublishOn(rxMqttClient));
         }
     }
 }

--- a/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
+++ b/src/MQTTnet.Extensions.External.RxMQTT.Client.Test/RxSubscriber.cs
@@ -25,8 +25,8 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
-			var rxMqttClinet = mock.Create<RxMqttClient>();
-			Assert.Throws<ArgumentException>(() => rxMqttClinet.Connect(topic));
+			var rxMqttClient = mock.Create<RxMqttClient>();
+			Assert.Throws<ArgumentException>(() => rxMqttClient.Connect(topic));
 		}
 
 		[Fact]
@@ -37,10 +37,10 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Throws(exceptin);
 			mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 			var testScheduler = new TestScheduler();
 
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 1);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("Topic"), 0, 0, 1);
 
 			Assert.Single(result.Messages);
 			Assert.Single(result.Messages.Where(record => record.Value.Kind == NotificationKind.OnError));
@@ -58,12 +58,12 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(exceptin);
 			mock.Mock<IMqttNetLogger>().Setup(x => x.IsEnabled).Returns(true);
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 			var testScheduler = new TestScheduler();
 
-			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClient.Connect("Topic"));
 
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("Topic"), 0, 0, 3);
 
 			Assert.Empty(result.Messages);
 			mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(It.IsAny<MqttNetLogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), exceptin), Times.Once);
@@ -77,12 +77,12 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			mock.Mock<IManagedMqttClient>().Setup(x => x.SubscribeAsync(It.IsAny<MqttTopicFilter[]>())).Returns(Task.CompletedTask);
 			mock.Mock<IManagedMqttClient>().Setup(x => x.UnsubscribeAsync(It.IsAny<string[]>())).Throws(new ObjectDisposedException(nameof(ManagedMqttClient)));
 			mock.Mock<IMqttNetLogger>();
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 			var testScheduler = new TestScheduler();
 
-			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClinet.Connect("Topic"));
+			testScheduler.Schedule(TimeSpan.FromTicks(2), () => rxMqttClient.Connect("Topic"));
 
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("Topic"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("Topic"), 0, 0, 3);
 
 			Assert.Empty(result.Messages);
 			mock.Mock<IMqttNetLogger>().Verify(x => x.Publish(MqttNetLogLevel.Error, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<Exception>()), Times.Never);
@@ -94,7 +94,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message1 = new MqttApplicationMessageBuilder()
 				.WithTopic("T")
@@ -114,7 +114,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			// act
 			var firstCount = 0;
-			var first = rxMqttClinet.Connect("T").Subscribe(_ => firstCount++);
+			var first = rxMqttClient.Connect("T").Subscribe(_ => firstCount++);
 
 			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
 			testScheduler.Schedule(TimeSpan.FromTicks(3), () => first.Dispose());
@@ -122,8 +122,8 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			var result = testScheduler.Start(() =>
 			{
-				IObservable<MqttApplicationMessageReceivedEventArgs> first = rxMqttClinet.Connect("T");
-				return rxMqttClinet.Connect("T");
+				IObservable<MqttApplicationMessageReceivedEventArgs> first = rxMqttClient.Connect("T");
+				return rxMqttClient.Connect("T");
 			}, 0, 0, 5);
 
 			// test
@@ -141,7 +141,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message1 = new MqttApplicationMessageBuilder()
 				.WithTopic("T")
@@ -162,7 +162,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			// act
 			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs1));
 			testScheduler.Schedule(TimeSpan.FromTicks(3), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync += null, (object)eventArgs2));
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("T"), 0, 0, 4);
 
 			// test
 			Assert.Equal(2, result.Messages.Count);
@@ -179,7 +179,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message = new MqttApplicationMessageBuilder()
 				.WithTopic("T")
@@ -190,8 +190,8 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			var testScheduler = new TestScheduler();
 
 			// act
-			testScheduler.Schedule(TimeSpan.FromTicks(3), () => rxMqttClinet.Dispose());
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 4);
+			testScheduler.Schedule(TimeSpan.FromTicks(3), () => rxMqttClient.Dispose());
+			var result = testScheduler.Start(() => rxMqttClient.Connect("T"), 0, 0, 4);
 
 			// test
 			Assert.Single(result.Messages);
@@ -204,7 +204,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message = new MqttApplicationMessageBuilder()
 				.WithTopic("N")
@@ -216,7 +216,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			// act
 			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("T"), 0, 0, 3);
 
 			// test
 			Assert.Empty(result.Messages);
@@ -229,7 +229,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message = new MqttApplicationMessageBuilder()
 				.WithTopic("T")
@@ -241,7 +241,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			// act
 			testScheduler.Schedule(TimeSpan.FromTicks(2), () => mock.Mock<IManagedMqttClient>().Raise(x => x.ApplicationMessageReceivedAsync -= null, (object)eventArgs));
-			var result = testScheduler.Start(() => rxMqttClinet.Connect("T"), 0, 0, 3);
+			var result = testScheduler.Start(() => rxMqttClient.Connect("T"), 0, 0, 3);
 
 			// test
 			Assert.Single(result.Messages);
@@ -255,7 +255,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
 
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message1 = new MqttApplicationMessageBuilder()
 				.WithTopic("T/A")
@@ -279,7 +279,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 
 			// set up first subscription
 			var result = testScheduler
-				.Start(() => rxMqttClinet.Connect("T/A").Merge(rxMqttClinet.Connect("T/+")), 0, 0, 4);
+				.Start(() => rxMqttClient.Connect("T/A").Merge(rxMqttClient.Connect("T/+")), 0, 0, 4);
 
 			// test
 			Assert.Equal(4, result.Messages.Count);
@@ -298,7 +298,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 		{
 			using var mock = AutoMock.GetLoose();
 			mock.Mock<IManagedMqttClient>();
-			var rxMqttClinet = mock.Create<RxMqttClient>();
+			var rxMqttClient = mock.Create<RxMqttClient>();
 
 			var message = new MqttApplicationMessageBuilder()
 				.WithTopic("T")
@@ -311,7 +311,7 @@ namespace MQTTnet.Extensions.External.RxMQTT.Client.Test
 				.Build();
 
 			// act
-			await rxMqttClinet.PublishAsync(mangedMessage);
+			await rxMqttClient.PublishAsync(mangedMessage);
 
 			// test
 			mock.Mock<IManagedMqttClient>().Verify(x => x.EnqueueAsync(mangedMessage));


### PR DESCRIPTION
Corrected the variable name `rxMqttClinet` to `rxMqttClient` across multiple instances in `MangedClientWrapperTest.cs`, `RxPublischer.cs`, and `RxSubscriber.cs`. Also fixed the typo `looger` to `logger` in the `Factory_NullException_With_Logger` and `Factory_With_Logger` test methods. These changes improve code readability and reduce the risk of errors due to misspelled variable names.