### PR TITLE
Add permissions section to ci-build.yml for write access

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,9 @@
 name: Build
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
The changes in the `ci-build.yml` file introduce a new `permissions` section. This section grants the workflow write access to the repository contents and packages. This is useful for workflows that need to modify repository files or manage packages as part of their execution.